### PR TITLE
Fixed broken weather-partlycloudy icon

### DIFF
--- a/custom_components/bom_forecast/sensor.py
+++ b/custom_components/bom_forecast/sensor.py
@@ -179,7 +179,7 @@ SENSOR_TYPES = {
 ICON_MAPPING = {
     '1': 'mdi:weather-sunny',
     '2': 'mdi:weather-night',
-    '3': 'mdi:weather-partlycloudy',
+    '3': 'mdi:weather-partly-cloudy',
     '4': 'mdi:weather-cloudy',
     '6': 'mdi:weather-sunset',
     '8': 'mdi:weather-rainy',


### PR DESCRIPTION
MDI changed the name of an icon from `weather-partlycloudy` to `weather-partly-cloudy`.

Details in https://github.com/home-assistant/home-assistant/issues/26257